### PR TITLE
phpenv

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule ".anyenv/envs/tfenv"]
 	path = .anyenv/envs/tfenv
 	url = https://github.com/tfutils/tfenv.git
+[submodule ".anyenv/envs/phpenv"]
+	path = .anyenv/envs/phpenv
+	url = https://github.com/phpenv/phpenv.git


### PR DESCRIPTION
## 概要
php のインストールに苦戦したのでメモしておく
```sh
anyenv install pipenv

// エラーが出たものたち
brew install bzip2
brew install libiconv
brew install tidy-html5
 brew install libzip

// ばかしんどかったエラー
export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"

// 最終コマンド
PHP_BUILD_CONFIGURE_OPTS="--with-bz2=/usr/local/opt/bzip2 --with-iconv=/usr/local/opt/libiconv --with-libxml=/usr/local/opt/libxml2/lib" phpenv install 8.0.0
```

## 参考リンク
[anyenv で phpenv をインストールする](https://qiita.com/zaburo/items/8ac16133c3823c6e6ad6)
[macOS に phpenv で PHP 8.0 をインストールする](https://qiita.com/dounokouno/items/0883ff318846072efbc4)
[macOS Catalina(10.15) の Xcode11 だと /usr/include が無い](https://qiita.com/yoya/items/c0b26cba3c040c581643)