### PR TITLE
pyenv 仕様変更による Warning

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -1,4 +1,3 @@
-eval "$(anyenv init -)"
 export PATH="$HOME/.anyenv/bin:$PATH"
 export PATH=$PATH:$HOME/.anyenv/.nodenv/shims/npm
 
@@ -10,15 +9,16 @@ export PATH=$PATH:$HOME/Desktop/zumo/gcc-arm-none-eabi-8-2018-q4-major/bin
 export PATH=$PATH:$HOME/.nodebrew/current/bin
 export PATH=$PATH:$HOME/usr/local/texlive/2019/texmf-dist/doc
 export PATH=LOCAL_PATH:$PATH
-export PATH=$PATH:$HOME/usr/local/Cellar
-export PATH=$PATH:$HOME/usr/local/Cellar/pyenv/1.2.15/plugins/python-build/share/python-build/
 export PATH=$PATH:$HOME/Applications/Postgres.app/Contents/Versions/latest/bin
 export PATH=$PATH:$HOME/flutter/bin
 export PATH=$PATH:$HOME/flutter/.pub-cache/bin
 
+export PYENV_ROOT="$HOME/.anyenv/envs/pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+eval "$(pyenv init --path)"
+eval "$(anyenv init -)"
+
 if [ -f ~/.zshrc ] ; then
   . ~/.zshrc
 fi
-
-
-

--- a/.zshrc
+++ b/.zshrc
@@ -6,6 +6,8 @@ source $ZPLUG_HOME/init.zsh
 
 source enhanced/init.sh
 
+eval "$(pyenv init -)"
+
 zplug "zsh-users/zsh-autosuggestions"
 zplug "zsh-users/zsh-syntax-highlighting"
 zplug "zsh-users/zsh-completions"


### PR DESCRIPTION
## 概要
ターミナル起動時に，以下のワーニングが発生していたので修正
```
Last login: Tue Jun 22 16:54:36 on ttys006
WARNING: `pyenv init -` no longer sets PATH.
Run `pyenv init` to see the necessary changes to make to your configuration.
```

参考のIssue
https://github.com/pyenv/pyenv/issues/1906